### PR TITLE
fix: Battery Info column alignment and remove redundant Columns (#5)

### DIFF
--- a/app/src/main/java/com/bharathvishal/batterystatsforandroid/activities/MainActivityCompose.kt
+++ b/app/src/main/java/com/bharathvishal/batterystatsforandroid/activities/MainActivityCompose.kt
@@ -32,6 +32,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -310,37 +311,27 @@ class MainActivityCompose : ComponentActivity() {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(5.dp),
+                .padding(5.dp)
+                .padding(horizontal = 24.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center,
+            horizontalArrangement = Arrangement.SpaceBetween,
         ) {
-            Column(
-                modifier = Modifier.weight(0.5f),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
-            ) {
-                Text(
-                    text = strDesc,
-                    textAlign = TextAlign.Left,
-                    modifier = Modifier
-                        .padding(5.dp),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.primary
-                )
-            }
-            Column(
-                modifier = Modifier.weight(0.5f),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
-            ) {
-                Text(
-                    text = mutableVal,
-                    textAlign = TextAlign.Right,
-                    modifier = Modifier
-                        .padding(5.dp),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-            }
+
+            Text(
+                text = strDesc,
+                textAlign = TextAlign.Left,
+                modifier = Modifier
+                    .padding(5.dp),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Text(
+                text = mutableVal,
+                textAlign = TextAlign.Right,
+                modifier = Modifier
+                    .padding(5.dp),
+                style = MaterialTheme.typography.bodyMedium,
+            )
         }
     }
 


### PR DESCRIPTION
fix: Battery Info column alignment and remove redundant Columns (#5)

Fixes #5

**Summary of changes:**
- Fixed misalignment in Battery Info `Column` by adjusting the `padding` and `horizontalArrangement`.
- Simplified `RowComponentInCard`: removed unnecessary nested `Column` composables; now each Text is directly a child in `Row`.

**Screenshots:**
_Before:_ 
<img  width="270" height="600" alt="Mis aligned stats card" src="https://github.com/user-attachments/assets/09897802-8b50-45b2-9fe9-540e206fc584" />

_After:_ 
<img width="270" height="600" alt="well-aligned stats card" src="https://github.com/user-attachments/assets/fe439af8-5f4f-4394-8802-4413f13487cc" />

**Testing:**
- Verified on real device. Alignment and display now match expectations.

No other files changed. This PR is limited to the scope of Issue #5.